### PR TITLE
Add Defender API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## 🚀 Features
 
-- Retrieves software vulnerabilities from Microsoft Defender API
+- Retrieves vulnerable software inventory from Microsoft Defender API
 - Allows selection of software for remediation
 - Creates tickets in ManageEngine ServiceDesk Plus (on-prem)
 - Simple Flask architecture
@@ -36,6 +36,8 @@ vreview/
 
 2. **Configure environment**
    - Copy `/backend/.env.example` to `/backend/.env` and adjust values as needed
+   - Set your Microsoft Defender credentials (`DEFENDER_TENANT_ID`,
+     `DEFENDER_CLIENT_ID`, `DEFENDER_CLIENT_SECRET`) for API access
 
 3. **Run containers**
    ```bash
@@ -55,7 +57,7 @@ vreview/
 
 ## 💪 Status
 
-> Core backend is scaffolded. Defender API and ServiceDesk Plus integration are in progress.
+Defender API integration is implemented for retrieving the vulnerable software inventory. ServiceDesk Plus integration is still in progress.
 
 ---
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,3 +9,8 @@ DATABASE_URL=postgresql://postgres:postgres@db/postgres
 POSTGRES_DB=postgres
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
+
+# Microsoft Defender API credentials
+DEFENDER_TENANT_ID=
+DEFENDER_CLIENT_ID=
+DEFENDER_CLIENT_SECRET=

--- a/backend/app/defender.py
+++ b/backend/app/defender.py
@@ -1,0 +1,33 @@
+import os
+import requests
+
+
+def get_access_token():
+    tenant_id = os.getenv("DEFENDER_TENANT_ID")
+    client_id = os.getenv("DEFENDER_CLIENT_ID")
+    client_secret = os.getenv("DEFENDER_CLIENT_SECRET")
+    if not all([tenant_id, client_id, client_secret]):
+        raise RuntimeError("Defender API credentials are not fully configured")
+
+    token_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+    data = {
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "scope": "https://api.securitycenter.microsoft.com/.default",
+        "grant_type": "client_credentials",
+    }
+    response = requests.post(token_url, data=data)
+    response.raise_for_status()
+    return response.json().get("access_token")
+
+
+def get_vulnerable_software():
+    token = get_access_token()
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    url = "https://api.securitycenter.microsoft.com/api/vulnerableSoftware"
+    response = requests.get(url, headers=headers)
+    response.raise_for_status()
+    return response.json()

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, jsonify
 from . import db
+from .defender import get_vulnerable_software
 
 api_bp = Blueprint('api', __name__)
 
@@ -15,3 +16,13 @@ def root():
 @api_bp.route('/hello', methods=['GET'])
 def hello():
     return jsonify({"message": "Hello from Flask!"})
+
+
+@api_bp.route('/vulnerable-software', methods=['GET'])
+def vulnerable_software():
+    """Return list of vulnerable software from Microsoft Defender."""
+    try:
+        data = get_vulnerable_software()
+        return jsonify(data)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,3 +15,4 @@ python-dotenv==1.1.0
 SQLAlchemy==2.0.40
 typing_extensions==4.13.1
 Werkzeug==3.1.3
+requests==2.31.0


### PR DESCRIPTION
## Summary
- integrate Microsoft Defender API
- add `vulnerable-software` API route
- document required Defender credentials and update project status
- include `requests` library

## Testing
- `python -m compileall backend/app`

------
https://chatgpt.com/codex/tasks/task_b_684bdc0276dc832683b00ff0f0b40e6f