### PR TITLE
Implement CRUD API endpoints

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -16,6 +16,18 @@ class Vulnerability(db.Model):
     def __repr__(self):
         return f'<Vulnerability {self.defender_id} - {self.title}>'
 
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "defender_id": self.defender_id,
+            "title": self.title,
+            "description": self.description,
+            "severity": self.severity,
+            "discovered_at": self.discovered_at.isoformat()
+            if self.discovered_at
+            else None,
+        }
+
 class Review(db.Model):
     __tablename__ = 'reviews'
     
@@ -24,9 +36,20 @@ class Review(db.Model):
     status = db.Column(db.String(50), default='pending')  # e.g., pending, in_review, remediated
     comments = db.Column(db.Text)
     reviewed_at = db.Column(db.DateTime)
-    
+
     def __repr__(self):
         return f'<Review for Vulnerability {self.vulnerability_id} - {self.status}>'
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "vulnerability_id": self.vulnerability_id,
+            "status": self.status,
+            "comments": self.comments,
+            "reviewed_at": self.reviewed_at.isoformat()
+            if self.reviewed_at
+            else None,
+        }
 
 class Ticket(db.Model):
     __tablename__ = 'tickets'
@@ -36,6 +59,17 @@ class Ticket(db.Model):
     ticket_number = db.Column(db.String(50), unique=True)
     status = db.Column(db.String(50), default='open')  # open, closed, in_progress, etc.
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    
+
     def __repr__(self):
         return f'<Ticket {self.ticket_number} for Review {self.review_id}>'
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "review_id": self.review_id,
+            "ticket_number": self.ticket_number,
+            "status": self.status,
+            "created_at": self.created_at.isoformat()
+            if self.created_at
+            else None,
+        }

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,5 +1,6 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 from . import db
+from .models import Vulnerability, Review, Ticket
 from .defender import get_vulnerable_software
 
 api_bp = Blueprint('api', __name__)
@@ -26,3 +27,203 @@ def vulnerable_software():
         return jsonify(data)
     except Exception as e:
         return jsonify({"error": str(e)}), 500
+
+
+# -------------------------- Vulnerability CRUD ---------------------------
+
+@api_bp.route('/vulnerabilities', methods=['GET'])
+def list_vulnerabilities():
+    vulnerabilities = Vulnerability.query.all()
+    return jsonify([v.to_dict() for v in vulnerabilities])
+
+
+@api_bp.route('/vulnerabilities/<int:vuln_id>', methods=['GET'])
+def get_vulnerability(vuln_id):
+    vulnerability = Vulnerability.query.get(vuln_id)
+    if not vulnerability:
+        return jsonify({'error': 'Vulnerability not found'}), 404
+    return jsonify(vulnerability.to_dict())
+
+
+@api_bp.route('/vulnerabilities', methods=['POST'])
+def create_vulnerability():
+    data = request.get_json() or {}
+    try:
+        vulnerability = Vulnerability(
+            defender_id=data['defender_id'],
+            title=data['title'],
+            description=data.get('description'),
+            severity=data.get('severity'),
+        )
+        db.session.add(vulnerability)
+        db.session.commit()
+        return jsonify(vulnerability.to_dict()), 201
+    except KeyError as e:
+        return jsonify({'error': f'Missing field: {e.args[0]}'}), 400
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'error': str(e)}), 500
+
+
+@api_bp.route('/vulnerabilities/<int:vuln_id>', methods=['PUT'])
+def update_vulnerability(vuln_id):
+    vulnerability = Vulnerability.query.get(vuln_id)
+    if not vulnerability:
+        return jsonify({'error': 'Vulnerability not found'}), 404
+    data = request.get_json() or {}
+    for field in ['defender_id', 'title', 'description', 'severity']:
+        if field in data:
+            setattr(vulnerability, field, data[field])
+    try:
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'error': str(e)}), 500
+    return jsonify(vulnerability.to_dict())
+
+
+@api_bp.route('/vulnerabilities/<int:vuln_id>', methods=['DELETE'])
+def delete_vulnerability(vuln_id):
+    vulnerability = Vulnerability.query.get(vuln_id)
+    if not vulnerability:
+        return jsonify({'error': 'Vulnerability not found'}), 404
+    try:
+        db.session.delete(vulnerability)
+        db.session.commit()
+        return jsonify({'message': 'Vulnerability deleted'})
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'error': str(e)}), 500
+
+
+# ----------------------------- Review CRUD ------------------------------
+
+@api_bp.route('/reviews', methods=['GET'])
+def list_reviews():
+    reviews = Review.query.all()
+    return jsonify([r.to_dict() for r in reviews])
+
+
+@api_bp.route('/reviews/<int:review_id>', methods=['GET'])
+def get_review(review_id):
+    review = Review.query.get(review_id)
+    if not review:
+        return jsonify({'error': 'Review not found'}), 404
+    return jsonify(review.to_dict())
+
+
+@api_bp.route('/reviews', methods=['POST'])
+def create_review():
+    data = request.get_json() or {}
+    try:
+        review = Review(
+            vulnerability_id=data['vulnerability_id'],
+            status=data.get('status', 'pending'),
+            comments=data.get('comments'),
+            reviewed_at=data.get('reviewed_at'),
+        )
+        db.session.add(review)
+        db.session.commit()
+        return jsonify(review.to_dict()), 201
+    except KeyError as e:
+        return jsonify({'error': f'Missing field: {e.args[0]}'}), 400
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'error': str(e)}), 500
+
+
+@api_bp.route('/reviews/<int:review_id>', methods=['PUT'])
+def update_review(review_id):
+    review = Review.query.get(review_id)
+    if not review:
+        return jsonify({'error': 'Review not found'}), 404
+    data = request.get_json() or {}
+    for field in ['vulnerability_id', 'status', 'comments', 'reviewed_at']:
+        if field in data:
+            setattr(review, field, data[field])
+    try:
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'error': str(e)}), 500
+    return jsonify(review.to_dict())
+
+
+@api_bp.route('/reviews/<int:review_id>', methods=['DELETE'])
+def delete_review(review_id):
+    review = Review.query.get(review_id)
+    if not review:
+        return jsonify({'error': 'Review not found'}), 404
+    try:
+        db.session.delete(review)
+        db.session.commit()
+        return jsonify({'message': 'Review deleted'})
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'error': str(e)}), 500
+
+
+# ------------------------------ Ticket CRUD -----------------------------
+
+@api_bp.route('/tickets', methods=['GET'])
+def list_tickets():
+    tickets = Ticket.query.all()
+    return jsonify([t.to_dict() for t in tickets])
+
+
+@api_bp.route('/tickets/<int:ticket_id>', methods=['GET'])
+def get_ticket(ticket_id):
+    ticket = Ticket.query.get(ticket_id)
+    if not ticket:
+        return jsonify({'error': 'Ticket not found'}), 404
+    return jsonify(ticket.to_dict())
+
+
+@api_bp.route('/tickets', methods=['POST'])
+def create_ticket():
+    data = request.get_json() or {}
+    try:
+        ticket = Ticket(
+            review_id=data['review_id'],
+            ticket_number=data.get('ticket_number'),
+            status=data.get('status', 'open'),
+        )
+        db.session.add(ticket)
+        db.session.commit()
+        return jsonify(ticket.to_dict()), 201
+    except KeyError as e:
+        return jsonify({'error': f'Missing field: {e.args[0]}'}), 400
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'error': str(e)}), 500
+
+
+@api_bp.route('/tickets/<int:ticket_id>', methods=['PUT'])
+def update_ticket(ticket_id):
+    ticket = Ticket.query.get(ticket_id)
+    if not ticket:
+        return jsonify({'error': 'Ticket not found'}), 404
+    data = request.get_json() or {}
+    for field in ['review_id', 'ticket_number', 'status']:
+        if field in data:
+            setattr(ticket, field, data[field])
+    try:
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'error': str(e)}), 500
+    return jsonify(ticket.to_dict())
+
+
+@api_bp.route('/tickets/<int:ticket_id>', methods=['DELETE'])
+def delete_ticket(ticket_id):
+    ticket = Ticket.query.get(ticket_id)
+    if not ticket:
+        return jsonify({'error': 'Ticket not found'}), 404
+    try:
+        db.session.delete(ticket)
+        db.session.commit()
+        return jsonify({'message': 'Ticket deleted'})
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'error': str(e)}), 500


### PR DESCRIPTION
## Summary
- serialize SQLAlchemy models with `to_dict`
- build REST routes for Vulnerability, Review and Ticket models

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685d00738b948326ae4fa4ebbe8428cb