### PR TITLE
Add Pytest suite and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ vreview/
 
 Defender API integration is implemented for retrieving the vulnerable software inventory. ServiceDesk Plus integration is still in progress.
 
+## 🧪 Running Tests
+
+Install dependencies and run the Pytest suite:
+
+```bash
+pip install -r backend/requirements.txt
+pip install pytest
+pytest
+```
+
 ---
 
 Feel free to fork, contribute, or raise issues!

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import os
+import pytest
+
+from backend.app import create_app, db
+
+@pytest.fixture
+def app():
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+    yield app
+    with app.app_context():
+        db.drop_all()
+
+@pytest.fixture
+def client(app):
+    return app.test_client()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,25 @@
+from unittest.mock import patch
+
+from backend.app import db
+from backend.app.models import Vulnerability
+
+
+def test_root_route(client):
+    response = client.get('/api/v1/')
+    data = response.get_json()
+    assert response.status_code == 200
+    assert 'message' in data
+
+
+def test_hello_route(client):
+    response = client.get('/api/v1/hello')
+    assert response.status_code == 200
+    assert response.get_json() == {"message": "Hello from Flask!"}
+
+
+def test_vulnerable_software_route(client):
+    sample = {"value": [{"id": "1", "name": "test"}]}
+    with patch('backend.app.routes.get_vulnerable_software', return_value=sample):
+        response = client.get('/api/v1/vulnerable-software')
+    assert response.status_code == 200
+    assert response.get_json() == sample

--- a/tests/test_servicedesk.py
+++ b/tests/test_servicedesk.py
@@ -1,0 +1,20 @@
+from backend.app import db
+from backend.app.models import Vulnerability, Review, Ticket
+
+
+def test_ticket_model_defaults(app):
+    with app.app_context():
+        vuln = Vulnerability(defender_id='v1', title='test', description='desc', severity='High')
+        db.session.add(vuln)
+        db.session.commit()
+
+        review = Review(vulnerability_id=vuln.id)
+        db.session.add(review)
+        db.session.commit()
+
+        ticket = Ticket(review_id=review.id, ticket_number='SDP-1')
+        db.session.add(ticket)
+        db.session.commit()
+
+        assert ticket.status == 'open'
+        assert 'SDP-1' in repr(ticket)


### PR DESCRIPTION
## Summary
- add pytest-based tests for the API routes
- add service desk model tests
- document how to run the tests

## Testing
- `pip install -q -r backend/requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_685d00908f508326bb6f79fd723165ec