### PR TITLE
Add vulnerability listing and ticket creation UI

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,6 +1,7 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 from . import db
 from .defender import get_vulnerable_software
+from .models import Vulnerability, Review, Ticket
 
 api_bp = Blueprint('api', __name__)
 
@@ -12,6 +13,50 @@ def root():
             return jsonify({"message": "DB connected!", "result": result.scalar()})
     except Exception as e:
         return jsonify({"error": str(e)}), 500
+
+
+@api_bp.route('/vulnerabilities', methods=['GET'])
+def list_vulnerabilities():
+    """Return vulnerabilities stored in the database."""
+    vulns = Vulnerability.query.all()
+    result = [
+        {
+            "id": v.id,
+            "defender_id": v.defender_id,
+            "title": v.title,
+            "description": v.description,
+            "severity": v.severity,
+        }
+        for v in vulns
+    ]
+    return jsonify(result)
+
+
+@api_bp.route('/tickets', methods=['POST'])
+def create_ticket():
+    """Create a ticket for a given vulnerability."""
+    data = request.get_json() or {}
+    vuln_id = data.get("vulnerability_id")
+    if not vuln_id:
+        return jsonify({"error": "vulnerability_id is required"}), 400
+
+    vulnerability = Vulnerability.query.get(vuln_id)
+    if not vulnerability:
+        return jsonify({"error": "vulnerability not found"}), 404
+
+    review = Review(vulnerability_id=vulnerability.id, status="pending")
+    db.session.add(review)
+    db.session.commit()
+
+    ticket_number = data.get("ticket_number") or f"TICKET-{review.id}"
+    ticket = Ticket(review_id=review.id, ticket_number=ticket_number)
+    db.session.add(ticket)
+    db.session.commit()
+
+    return (
+        jsonify({"id": ticket.id, "ticket_number": ticket.ticket_number, "status": ticket.status}),
+        201,
+    )
 
 @api_bp.route('/hello', methods=['GET'])
 def hello():

--- a/backend/app/static/index.html
+++ b/backend/app/static/index.html
@@ -2,11 +2,67 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>VReview</title>
+    <style>
+        table {
+            border-collapse: collapse;
+            width: 100%;
+        }
+        th, td {
+            border: 1px solid #ccc;
+            padding: 8px;
+        }
+    </style>
 </head>
 <body>
-    <h1>Welcome to VReview</h1>
-    <p>The frontend is served by Flask.</p>
+    <h1>Stored Vulnerabilities</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>Select</th>
+                <th>Title</th>
+                <th>Severity</th>
+            </tr>
+        </thead>
+        <tbody id="vuln-table-body">
+            <!-- Content populated via JavaScript -->
+        </tbody>
+    </table>
+    <button id="create-ticket-btn">Create Tickets</button>
+
+    <script>
+        async function loadVulnerabilities() {
+            const resp = await fetch('/api/v1/vulnerabilities');
+            const data = await resp.json();
+            const body = document.getElementById('vuln-table-body');
+            body.innerHTML = '';
+            data.forEach(v => {
+                const row = document.createElement('tr');
+                row.innerHTML = `
+                    <td><input type="checkbox" value="${v.id}"></td>
+                    <td>${v.title}</td>
+                    <td>${v.severity || ''}</td>
+                `;
+                body.appendChild(row);
+            });
+        }
+
+        async function createTickets() {
+            const checked = document.querySelectorAll('#vuln-table-body input[type=checkbox]:checked');
+            for (const c of checked) {
+                await fetch('/api/v1/tickets', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ vulnerability_id: c.value })
+                });
+            }
+            alert('Tickets created');
+            loadVulnerabilities();
+        }
+
+        document.getElementById('create-ticket-btn').addEventListener('click', createTickets);
+        window.onload = loadVulnerabilities;
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add endpoints for listing vulnerabilities and creating tickets
- expand the static page with JavaScript to display vulnerabilities from the database
- allow users to create tickets for selected vulnerabilities

## Testing
- `python -m py_compile backend/app/routes.py`

------
https://chatgpt.com/codex/tasks/task_b_685d008c59688326907cfe95eb1ef55a