### PR TITLE
Serve static pages at root

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -15,7 +15,9 @@ migrate = Migrate()
 
 
 def create_app(config_class=Config):
-    app = Flask(__name__, static_folder="static")
+    # Serve static files (HTML frontend) from the root URL so that
+    # paths like `/dashboard.html` work without an extra `/static` prefix.
+    app = Flask(__name__, static_folder="static", static_url_path="")
     app.config.from_object(config_class)
 
     # Initialize extensions

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -40,3 +40,15 @@ def test_create_ticket_from_vulnerability(client, app):
     assert data['ticket_number']
     assert data['status'] == 'open'
 
+
+def test_dashboard_page_served(client):
+    resp = client.get('/dashboard.html')
+    assert resp.status_code == 200
+    assert b'VReview - Dashboard' in resp.data
+
+
+def test_reviews_page_served(client):
+    resp = client.get('/reviews.html')
+    assert resp.status_code == 200
+    assert b'VReview - Reviews' in resp.data
+


### PR DESCRIPTION
## Summary
- configure Flask to serve static files directly from the root URL
- add tests ensuring dashboard and reviews pages load

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_685e4df00b0c8326af85fd7c5536a9ba