### PR TITLE
Fix DataTable reinitialization on reload

### DIFF
--- a/backend/app/static/index.html
+++ b/backend/app/static/index.html
@@ -69,6 +69,9 @@
                 body.appendChild(row);
             });
 
+            if ($.fn.dataTable.isDataTable('#vuln-table')) {
+                $('#vuln-table').DataTable().destroy();
+            }
             $('#vuln-table').DataTable();
         }
 

--- a/backend/app/static/reviews.html
+++ b/backend/app/static/reviews.html
@@ -54,6 +54,9 @@
                 `;
                 body.appendChild(row);
             });
+            if ($.fn.dataTable.isDataTable('#reviews-table')) {
+                $('#reviews-table').DataTable().destroy();
+            }
             $('#reviews-table').DataTable();
         }
         window.onload = loadReviews;

--- a/backend/app/static/tickets.html
+++ b/backend/app/static/tickets.html
@@ -54,6 +54,9 @@
                 `;
                 body.appendChild(row);
             });
+            if ($.fn.dataTable.isDataTable('#tickets-table')) {
+                $('#tickets-table').DataTable().destroy();
+            }
             $('#tickets-table').DataTable();
         }
         window.onload = loadTickets;


### PR DESCRIPTION
## Summary
- avoid reinitializing existing DataTables on the vulnerability, review, and ticket pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_685e4ee9f2ac83268ccab28add56edf4