### PR TITLE
Fix env loading and add index page test

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -6,8 +6,10 @@ from dotenv import load_dotenv
 
 from .config import Config
 
-# Load .env from backend/.env explicitly
-load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), '../.env'))
+# Load .env file. Prefer repository root `.env` as documented in README
+# so running the app outside of Docker picks up local configuration.
+root_env = os.path.join(os.path.dirname(__file__), '../../.env')
+load_dotenv(dotenv_path=root_env)
 
 # Initialize extensions
 db = SQLAlchemy()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -11,6 +11,12 @@ def test_root_route(client):
     assert 'message' in data
 
 
+def test_index_page_served(client):
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert b'Stored Vulnerabilities' in resp.data
+
+
 def test_hello_route(client):
     response = client.get('/api/v1/hello')
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- ensure backend loads .env from repository root
- add test covering `/` index page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_685e517a9d6c8326a8b5469934638874