### PR TITLE
Add Defender credential verification

### DIFF
--- a/backend/app/defender.py
+++ b/backend/app/defender.py
@@ -2,10 +2,11 @@ import os
 import requests
 
 
-def get_access_token():
-    tenant_id = os.getenv("DEFENDER_TENANT_ID")
-    client_id = os.getenv("DEFENDER_CLIENT_ID")
-    client_secret = os.getenv("DEFENDER_CLIENT_SECRET")
+def get_access_token(tenant_id=None, client_id=None, client_secret=None):
+    """Retrieve an API access token using provided or environment credentials."""
+    tenant_id = tenant_id or os.getenv("DEFENDER_TENANT_ID")
+    client_id = client_id or os.getenv("DEFENDER_CLIENT_ID")
+    client_secret = client_secret or os.getenv("DEFENDER_CLIENT_SECRET")
     if not all([tenant_id, client_id, client_secret]):
         raise RuntimeError("Defender API credentials are not fully configured")
 
@@ -31,3 +32,12 @@ def get_vulnerable_software():
     response = requests.get(url, headers=headers)
     response.raise_for_status()
     return response.json()
+
+
+def verify_credentials(tenant_id, client_id, client_secret):
+    """Return True if a token can be acquired using the supplied credentials."""
+    try:
+        get_access_token(tenant_id, client_id, client_secret)
+        return True
+    except Exception:
+        return False

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -333,3 +333,17 @@ def save_settings():
     data = request.get_json() or {}
     # Settings persistence not implemented; just acknowledge receipt
     return jsonify({'saved': True, 'received': data})
+
+
+@api_bp.route('/verify-defender', methods=['POST'])
+def verify_defender():
+    """Verify Microsoft Defender credentials by attempting authentication."""
+    data = request.get_json() or {}
+    tenant = data.get('tenant_id')
+    client = data.get('client_id')
+    secret = data.get('client_secret')
+    try:
+        get_access_token(tenant, client, secret)
+        return jsonify({'valid': True})
+    except Exception as e:
+        return jsonify({'valid': False, 'error': str(e)}), 400

--- a/backend/app/static/settings.html
+++ b/backend/app/static/settings.html
@@ -28,6 +28,7 @@
             <label>Client ID <input type="text" id="client-id"></label>
             <label>Client Secret <input type="password" id="client-secret"></label>
             <button type="submit">Save</button>
+            <button type="button" id="verify-btn">Verify</button>
         </form>
     </div>
 
@@ -45,6 +46,25 @@
                 body: JSON.stringify(payload)
             });
             alert('Settings saved');
+        });
+
+        document.getElementById('verify-btn').addEventListener('click', async () => {
+            const payload = {
+                tenant_id: document.getElementById('tenant-id').value,
+                client_id: document.getElementById('client-id').value,
+                client_secret: document.getElementById('client-secret').value
+            };
+            const resp = await fetch('/api/v1/verify-defender', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            const result = await resp.json();
+            if (result.valid) {
+                alert('Credentials verified');
+            } else {
+                alert('Verification failed: ' + (result.error || 'Unknown error'));
+            }
         });
     </script>
 </body>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -109,3 +109,27 @@ def test_export_vulnerabilities_csv(client, app):
     assert 'id,defender_id,title,severity' in csv_text
     assert f"{vuln_id},v1,Test Vuln,High" in csv_text
 
+
+def test_verify_defender_success(client):
+    with patch('backend.app.routes.get_access_token', return_value='tok'):
+        resp = client.post('/api/v1/verify-defender', json={
+            'tenant_id': 't',
+            'client_id': 'c',
+            'client_secret': 's'
+        })
+    assert resp.status_code == 200
+    assert resp.get_json() == {'valid': True}
+
+
+def test_verify_defender_failure(client):
+    with patch('backend.app.routes.get_access_token', side_effect=RuntimeError('bad')):
+        resp = client.post('/api/v1/verify-defender', json={
+            'tenant_id': 't',
+            'client_id': 'c',
+            'client_secret': 's'
+        })
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data['valid'] is False
+    assert 'error' in data
+


### PR DESCRIPTION
## Summary
- update `get_access_token` to accept parameters
- add `verify_credentials` helper
- implement `/api/v1/verify-defender` route
- expose Verify button on settings page
- test verifying defender credentials

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_685e53acef808326877736545c885c21