### PR TITLE
Improve setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,12 @@ vreview/
    ```
 
 2. **Configure environment**
-   - Copy `./.env.example` to `./.env` and adjust values as needed
+   - Copy `.env.example` to `.env` and adjust values as needed
+     ```bash
+     cp .env.example .env
+     ```
+   - The database credentials in `.env` are used by both the Flask app and the
+     Postgres service
    - Set your Microsoft Defender credentials (`DEFENDER_TENANT_ID`,
      `DEFENDER_CLIENT_ID`, `DEFENDER_CLIENT_SECRET`) for API access
 


### PR DESCRIPTION
## Summary
- clarify environment file copy step before running Docker
- mention that database credentials are shared between Flask and Postgres

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `./setup_tests.sh` *(fails to install dependencies: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_685e57033ab483268b09e5d97e1a1088